### PR TITLE
Issue#5 Text shared 컴포넌트 구현 및 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@emotion/react": "^11.11.3",
+    "@emotion/styled": "^11.11.0",
     "@tanstack/react-query": "^5.17.10",
     "axios": "^1.6.5",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@emotion/react':
     specifier: ^11.11.3
     version: 11.11.3(@types/react@18.2.45)(react@18.2.0)
+  '@emotion/styled':
+    specifier: ^11.11.0
+    version: 11.11.0(@emotion/react@11.11.3)(@types/react@18.2.45)(react@18.2.0)
   '@tanstack/react-query':
     specifier: ^5.17.10
     version: 5.17.10(react@18.2.0)
@@ -143,6 +146,12 @@ packages:
     resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
     dev: false
 
+  /@emotion/is-prop-valid@1.2.1:
+    resolution: {integrity: sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==}
+    dependencies:
+      '@emotion/memoize': 0.8.1
+    dev: false
+
   /@emotion/memoize@0.8.1:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
     dev: false
@@ -180,6 +189,27 @@ packages:
 
   /@emotion/sheet@1.2.2:
     resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
+    dev: false
+
+  /@emotion/styled@11.11.0(@emotion/react@11.11.3)(@types/react@18.2.45)(react@18.2.0):
+    resolution: {integrity: sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==}
+    peerDependencies:
+      '@emotion/react': ^11.0.0-rc.0
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.8
+      '@emotion/babel-plugin': 11.11.0
+      '@emotion/is-prop-valid': 1.2.1
+      '@emotion/react': 11.11.3(@types/react@18.2.45)(react@18.2.0)
+      '@emotion/serialize': 1.1.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
+      '@emotion/utils': 1.2.1
+      '@types/react': 18.2.45
+      react: 18.2.0
     dev: false
 
   /@emotion/unitless@0.8.1:

--- a/src/auth/SignForm.tsx
+++ b/src/auth/SignForm.tsx
@@ -7,8 +7,8 @@ import {
   PropsWithChildren,
   forwardRef,
 } from 'react';
-import { color } from '../styles/color';
-import { typography } from '../styles/typography';
+import { colorPalette } from '../styles/colorPalette';
+import { typographyMap } from '../styles/typography';
 
 export default function SignForm({ children, ...props }: PropsWithChildren<FormHTMLAttributes<HTMLFormElement>>) {
   return (
@@ -17,8 +17,8 @@ export default function SignForm({ children, ...props }: PropsWithChildren<FormH
         width: 480,
         height: 560,
         borderRadius: 8,
-        boxShadow: `0px 0px 3px 3px ${color.gray1}`,
-        backgroundColor: color.white,
+        boxShadow: `0px 0px 3px 3px ${colorPalette.gray1}`,
+        backgroundColor: colorPalette.white,
         padding: '128px 56px 0',
 
         display: 'flex',
@@ -55,7 +55,7 @@ function Description({ content }: { content: string }) {
         fontSize: '16px',
         fontWeight: '400',
         letterSpacing: '-0.01em',
-        color: color.gray3,
+        color: colorPalette.gray3,
       })}
     >
       {content}
@@ -85,15 +85,15 @@ const Input = forwardRef(function Input(
           width: '100%',
           height: 56,
           padding: '0px 16px',
-          border: error ? `1px solid ${color.red}` : `1px solid ${color.gray2}`,
+          border: error ? `1px solid ${colorPalette.red}` : `1px solid ${colorPalette.gray2}`,
           borderRadius: '4px',
 
           [':focus']: {
-            border: error ? `1px solid ${color.red}` : `1px solid blue`,
+            border: error ? `1px solid ${colorPalette.red}` : `1px solid blue`,
           },
 
           ['::placeholder']: {
-            color: color.gray3,
+            color: colorPalette.gray3,
           },
         })}
         {...props}
@@ -103,7 +103,7 @@ const Input = forwardRef(function Input(
           css={css({
             width: '100%',
             textAlign: 'left',
-            color: color.red,
+            color: colorPalette.red,
             position: 'absolute',
             bottom: -25,
           })}
@@ -119,12 +119,12 @@ function Button({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>)
   return (
     <button
       css={css([
-        typography.body2,
+        typographyMap.body2,
         {
           width: '100%',
           height: 56,
-          backgroundColor: color.black,
-          color: color.white,
+          backgroundColor: colorPalette.black,
+          color: colorPalette.white,
           borderRadius: '4px',
         },
       ])}
@@ -139,7 +139,7 @@ function Addition({ children }: PropsWithChildren) {
   return (
     <span
       css={css({
-        color: color.gray3,
+        color: colorPalette.gray3,
         position: 'absolute',
         bottom: -40,
       })}

--- a/src/auth/SignForm.tsx
+++ b/src/auth/SignForm.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react';
 import { colorPalette } from '../styles/colorPalette';
 import { typographyMap } from '../styles/typography';
+import Text from '../shared/Text';
 
 export default function SignForm({ children, ...props }: PropsWithChildren<FormHTMLAttributes<HTMLFormElement>>) {
   return (
@@ -34,32 +35,13 @@ export default function SignForm({ children, ...props }: PropsWithChildren<FormH
 
 function Title({ name }: { name: string }) {
   return (
-    <h2
-      css={css({
-        fontSize: '32px',
-        fontWeight: '500',
-        letterSpacing: '-0.02em',
-        lineHeight: '1.3em',
-        textAlign: 'center',
-      })}
-    >
-      {name}
-    </h2>
+    <Text as='h2' typography="headline" textAlign="center">{name}</Text>
   );
 }
 
 function Description({ content }: { content: string }) {
   return (
-    <p
-      css={css({
-        fontSize: '16px',
-        fontWeight: '400',
-        letterSpacing: '-0.01em',
-        color: colorPalette.gray3,
-      })}
-    >
-      {content}
-    </p>
+    <Text as='p' typography="body2" color='gray3'>{content}</Text>
   );
 }
 

--- a/src/auth/login/components/LoginPassword.tsx
+++ b/src/auth/login/components/LoginPassword.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { color } from '../../../styles/color';
+import { colorPalette } from '../../../styles/colorPalette';
 import { css } from '@emotion/react';
-import { typography } from '../../../styles/typography';
+import { typographyMap } from '../../../styles/typography';
 import { useLogin, useLoginDispatch } from '../../../pages/LoginPage';
 import { postLogin } from '../remotes/query';
 import SignForm from '../../SignForm';
@@ -77,7 +77,7 @@ export default function LoginPassword() {
         <button
           type="button"
           onClick={() => navigate('/reset/email')}
-          css={css([typography.smallBody, { marginTop: 24 }])}
+          css={css([typographyMap.smallBody, { marginTop: 24 }])}
         >
           Did you forget your password?
         </button>
@@ -110,7 +110,7 @@ export default function LoginPassword() {
 
       <SignForm.Addition>
         No account?{' '}
-        <Link to="/signup/email" css={css({ textDecoration: 'none', color: color.darkGray })}>
+        <Link to="/signup/email" css={css({ textDecoration: 'none', color: colorPalette.darkGray })}>
           Create one
         </Link>
       </SignForm.Addition>

--- a/src/auth/reset/components/ResetVerification.tsx
+++ b/src/auth/reset/components/ResetVerification.tsx
@@ -1,9 +1,9 @@
 import { useNavigate } from 'react-router-dom';
 import { css } from '@emotion/react';
-import { typography } from '../../../styles/typography';
+import { typographyMap } from '../../../styles/typography';
 import SignForm from '../../SignForm';
 import { useReset, useResetDispatch } from '../../../pages/ResetPage';
-import { color } from '../../../styles/color';
+import { colorPalette } from '../../../styles/colorPalette';
 import { Spacing } from '../../../shared/Spacing';
 import envelopeBlackIcon from '../../../assets/icons/envelope-black.svg';
 
@@ -39,7 +39,7 @@ export default function ResetVerification() {
         onClick={() => {
           // postEmailVerification({ email });
         }}
-        css={css([typography.smallBody, { color: color.darkGray }])}
+        css={css([typographyMap.smallBody, { color: colorPalette.darkGray }])}
       >
         <img
           src={envelopeBlackIcon}

--- a/src/auth/signup/components/SignupVerification.tsx
+++ b/src/auth/signup/components/SignupVerification.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { css } from '@emotion/react';
 import SignForm from '../../SignForm';
-import { typography } from '../../../styles/typography';
-import { color } from '../../../styles/color';
+import { typographyMap } from '../../../styles/typography';
+import { colorPalette } from '../../../styles/colorPalette';
 import { useSignup, useSignupDispatch } from '../../../pages/SignupPage';
 import { Spacing } from '../../../shared/Spacing';
 import { postEmailVerification, postEmailVerificationCheck } from '../remotes/query';
@@ -63,9 +63,9 @@ export default function SignupVerification() {
             postEmailVerification({ email });
           }}
           css={css([
-            typography.smallBody,
+            typographyMap.smallBody,
             {
-              color: color.darkGray,
+              color: colorPalette.darkGray,
             },
           ])}
         >

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,16 +1,16 @@
 import { css } from '@emotion/react';
 import { Link } from 'react-router-dom';
-import { typography } from '../styles/typography';
-import { color } from '../styles/color';
+import { typographyMap } from '../styles/typography';
+import { colorPalette } from '../styles/colorPalette';
 
 export default function MainPage() {
   return (
     <div>
       <h2
         css={css([
-          typography.headline,
+          typographyMap.headline,
           {
-            color: color.darkGray,
+            color: colorPalette.darkGray,
           },
         ])}
       >
@@ -24,9 +24,9 @@ export default function MainPage() {
       >
         <Link
           css={css([
-            typography.body2,
+            typographyMap.body2,
             {
-              color: color.red,
+              color: colorPalette.red,
             },
           ])}
           to="/login/email"
@@ -35,9 +35,9 @@ export default function MainPage() {
         </Link>
         <Link
           css={css([
-            typography.body2,
+            typographyMap.body2,
             {
-              color: color.red,
+              color: colorPalette.red,
             },
           ])}
           to="/signup/email"
@@ -46,9 +46,9 @@ export default function MainPage() {
         </Link>
         <Link
           css={css([
-            typography.body2,
+            typographyMap.body2,
             {
-              color: color.red,
+              color: colorPalette.red,
             },
           ])}
           to="/reset/email"

--- a/src/shared/Text.tsx
+++ b/src/shared/Text.tsx
@@ -1,0 +1,22 @@
+import { CSSProperties } from 'react';
+import { Color, colorPalette } from '../styles/colorPalette';
+import { Typography, typographyMap } from '../styles/typography';
+import styled from '@emotion/styled';
+
+interface TextProps {
+  typography: Typography;
+  color?: Color;
+  display?: CSSProperties['display'];
+  textAlign?: CSSProperties['textAlign'];
+}
+
+const Text = styled.span<TextProps>(
+  ({ typography = 'body2' }) => typographyMap[typography],
+  ({ color = 'black', display, textAlign }) => ({
+    color: colorPalette[color],
+    display,
+    textAlign,
+  })
+);
+
+export default Text;

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -18,4 +18,4 @@ export const color = {
   black: '#000000',
 };
 
-export type Colors = keyof typeof color;
+export type Color = keyof typeof color;

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -17,3 +17,5 @@ export const color = {
   white: '#FFFFFF',
   black: '#000000',
 };
+
+export type Colors = keyof typeof color;

--- a/src/styles/colorPalette.ts
+++ b/src/styles/colorPalette.ts
@@ -1,4 +1,4 @@
-export const color = {
+export const colorPalette = {
   // main color
   darkGray: '#131313',
 
@@ -18,4 +18,4 @@ export const color = {
   black: '#000000',
 };
 
-export type Color = keyof typeof color;
+export type Color = keyof typeof colorPalette;

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-export const typography = {
+export const typographyMap = {
   headline: css`
     font-size: 32px;
     font-weight: 500;
@@ -27,4 +27,4 @@ export const typography = {
   `,
 };
 
-export type Typography = keyof typeof typography;
+export type Typography = keyof typeof typographyMap;

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,26 +1,30 @@
+import { css } from '@emotion/react';
+
 export const typography = {
-  headline: {
-    fontSize: '32px',
-    fontWeight: '500',
-    letterSpacing: '-0.02em',
-    lineHeight: '1.3em',
-  },
+  headline: css`
+    font-size: 32px;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    line-height: 1.3em;
+  `,
 
-  body1: {
-    fontSize: '16px',
-    fontWeight: '500',
-    letterSpacing: '-0.01em',
-  },
+  body1: css`
+    font-size: 16px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+  `,
 
-  body2: {
-    fontSize: '16px',
-    fontWeight: '400',
-    letterSpacing: '-0.01em',
-  },
+  body2: css`
+    font-size: 16px;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+  `,
 
-  smallBody: {
-    fontSize: '14px',
-    fontWeight: '400',
-    letterSpacing: '-0.01em',
-  },
+  smallBody: css`
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+  `,
 };
+
+export type Typography = keyof typeof typography;


### PR DESCRIPTION
## 🤷 구현한 기능
Text 컴포넌트 구현

## 🔨 상세 작업 내용

- [x] typography css 리터럴 템플릿 함수 적용
- [x] emotion/styled 의존성 추가
- [x] typography 타입 추가
- [x] color 객체의 네이밍을 colors로 변경 및 타입 추가

## 확인 요망
- color -> colorPalette, typography -> typographyMap으로 네이밍 변경
- color: color[color] 와 같이 작성할 때에 color를 color 객체가 아닌 props로 전달받은 color로 인식하는 문제 때문

## 📄 참고 사항
[Notion](https://www.notion.so/2024-01-18-7b216242a7a14b73aa75c85cf945537a?pvs=4#4a05ce16f2d94dbda57de53879ba824e)

## #️⃣ 연관된 이슈

close #5 