### PR TITLE
"회원가입"이라는 기능을 하나의 useForm 인스턴스로 관리한다

### DIFF
--- a/src/auth/signup/components/SignupEmail.tsx
+++ b/src/auth/signup/components/SignupEmail.tsx
@@ -1,5 +1,5 @@
 import SignForm from '../../SignForm';
-import { SignupFields } from '../../../pages/SignupPage';
+import { SignupStepFields } from '../../../pages/SignupPage';
 import { Spacing } from '../../../shared/Spacing';
 import { postEmailVerification } from '../remotes/query';
 import envelopeWhiteIcon from '../../../assets/icons/envelope-white.svg';
@@ -17,9 +17,9 @@ export default function SignupEmail({ nextStep }: SignupEmailProps) {
     register,
     handleSubmit,
     formState: { errors },
-  } = useFormContext<SignupFields>();
+  } = useFormContext<SignupStepFields>();
 
-  const onSubmit: SubmitHandler<SignupFields> = ({ email }) => {
+  const onSubmit: SubmitHandler<SignupStepFields> = ({ emailStep: { email } }) => {
     postEmailVerification({ email })
       .then(() => {
         nextStep();
@@ -35,16 +35,16 @@ export default function SignupEmail({ nextStep }: SignupEmailProps) {
       <Spacing size={8} />
       <SignForm.Description content="Enter your Email. We will send you verification code." />
       <Spacing size={32} />
-      <InputField type="text" bottomText={errors.email?.message}>
+      <InputField type="text" bottomText={errors.emailStep?.email?.message}>
         <SignForm.Input
-          {...register('email', {
+          {...register('emailStep.email', {
             required: {
               value: true,
               message: 'Please enter your email.',
             },
           })}
           placeholder="Email"
-          hasError={!!errors.email}
+          hasError={!!errors.emailStep?.email}
         />
       </InputField>
       <Spacing size={56} />

--- a/src/auth/signup/components/SignupEmail.tsx
+++ b/src/auth/signup/components/SignupEmail.tsx
@@ -1,33 +1,31 @@
 import SignForm from '../../SignForm';
-import { SignupData } from '../../../pages/SignupPage';
+import { SignupFields } from '../../../pages/SignupPage';
 import { Spacing } from '../../../shared/Spacing';
 import { postEmailVerification } from '../remotes/query';
 import envelopeWhiteIcon from '../../../assets/icons/envelope-white.svg';
 import { css } from '@emotion/react';
 import InputField from '../../../shared/InputField';
-import { SubmitHandler, useForm } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import { AxiosError } from 'axios';
-
-interface FormFields {
-  email: string;
-}
+import { FormEvent } from 'react';
 
 interface SignupEmailProps {
-  setSignupData: (key: keyof SignupData, value: SignupData[keyof SignupData]) => void;
   nextStep: () => void;
 }
 
-export default function SignupEmail({ setSignupData, nextStep }: SignupEmailProps) {
+export default function SignupEmail({ nextStep }: SignupEmailProps) {
   const {
     register,
-    handleSubmit,
+    getValues,
     formState: { errors },
-  } = useForm<FormFields>();
+  } = useFormContext<SignupFields>();
 
-  const submitEmail: SubmitHandler<FormFields> = ({ email }) => {
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const { email } = getValues();
+
     postEmailVerification({ email })
       .then(() => {
-        setSignupData('email', email);
         nextStep();
       })
       .catch((error: AxiosError<{ error_code: string; detail: string }>) => {
@@ -36,7 +34,7 @@ export default function SignupEmail({ setSignupData, nextStep }: SignupEmailProp
   };
 
   return (
-    <SignForm onSubmit={handleSubmit(submitEmail)}>
+    <SignForm onSubmit={onSubmit}>
       <SignForm.Title name="Sign up" />
       <Spacing size={8} />
       <SignForm.Description content="Enter your Email. We will send you verification code." />

--- a/src/auth/signup/components/SignupEmail.tsx
+++ b/src/auth/signup/components/SignupEmail.tsx
@@ -5,9 +5,8 @@ import { postEmailVerification } from '../remotes/query';
 import envelopeWhiteIcon from '../../../assets/icons/envelope-white.svg';
 import { css } from '@emotion/react';
 import InputField from '../../../shared/InputField';
-import { useFormContext } from 'react-hook-form';
+import { SubmitHandler, useFormContext } from 'react-hook-form';
 import { AxiosError } from 'axios';
-import { FormEvent } from 'react';
 
 interface SignupEmailProps {
   nextStep: () => void;
@@ -16,14 +15,11 @@ interface SignupEmailProps {
 export default function SignupEmail({ nextStep }: SignupEmailProps) {
   const {
     register,
-    getValues,
+    handleSubmit,
     formState: { errors },
   } = useFormContext<SignupFields>();
 
-  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const { email } = getValues();
-
+  const onSubmit: SubmitHandler<SignupFields> = ({ email }) => {
     postEmailVerification({ email })
       .then(() => {
         nextStep();
@@ -34,7 +30,7 @@ export default function SignupEmail({ nextStep }: SignupEmailProps) {
   };
 
   return (
-    <SignForm onSubmit={onSubmit}>
+    <SignForm onSubmit={handleSubmit(onSubmit)}>
       <SignForm.Title name="Sign up" />
       <Spacing size={8} />
       <SignForm.Description content="Enter your Email. We will send you verification code." />
@@ -42,7 +38,10 @@ export default function SignupEmail({ nextStep }: SignupEmailProps) {
       <InputField type="text" bottomText={errors.email?.message}>
         <SignForm.Input
           {...register('email', {
-            required: true,
+            required: {
+              value: true,
+              message: 'Please enter your email.',
+            },
           })}
           placeholder="Email"
           hasError={!!errors.email}

--- a/src/auth/signup/components/SignupEmail.tsx
+++ b/src/auth/signup/components/SignupEmail.tsx
@@ -1,5 +1,5 @@
 import SignForm from '../../SignForm';
-import { SignupStepFields } from '../../../pages/SignupPage';
+import { SignupFields } from '../../../pages/SignupPage';
 import { Spacing } from '../../../shared/Spacing';
 import { postEmailVerification } from '../remotes/query';
 import envelopeWhiteIcon from '../../../assets/icons/envelope-white.svg';
@@ -17,9 +17,9 @@ export default function SignupEmail({ nextStep }: SignupEmailProps) {
     register,
     handleSubmit,
     formState: { errors },
-  } = useFormContext<SignupStepFields>();
+  } = useFormContext<SignupFields>();
 
-  const onSubmit: SubmitHandler<SignupStepFields> = ({ emailStep: { email } }) => {
+  const onSubmit: SubmitHandler<SignupFields> = ({ email }) => {
     postEmailVerification({ email })
       .then(() => {
         nextStep();
@@ -35,16 +35,16 @@ export default function SignupEmail({ nextStep }: SignupEmailProps) {
       <Spacing size={8} />
       <SignForm.Description content="Enter your Email. We will send you verification code." />
       <Spacing size={32} />
-      <InputField type="text" bottomText={errors.emailStep?.email?.message}>
+      <InputField type="text" bottomText={errors.email?.message}>
         <SignForm.Input
-          {...register('emailStep.email', {
+          {...register('email', {
             required: {
               value: true,
               message: 'Please enter your email.',
             },
           })}
           placeholder="Email"
-          hasError={!!errors.emailStep?.email}
+          hasError={!!errors.email}
         />
       </InputField>
       <Spacing size={56} />

--- a/src/auth/signup/components/SignupPassword.tsx
+++ b/src/auth/signup/components/SignupPassword.tsx
@@ -3,31 +3,24 @@ import SignForm from '../../SignForm';
 import { Spacing } from '../../../shared/Spacing';
 import Addition from '../../Addition';
 import InputField from '../../../shared/InputField';
-import { SubmitHandler, useForm } from 'react-hook-form';
-import { SignupData } from '../../../pages/SignupPage';
-import { postSignup } from '../remotes/query';
-
-interface FormFields {
-  password: string;
-  confirmPassword: string;
-}
+import { SubmitHandler, useFormContext } from 'react-hook-form';
+import { SignupRequest } from '../remotes/query';
+import { SignupFields } from '../../../pages/SignupPage';
 
 interface SignupPasswordProps {
-  signupData: SignupData;
+  signup: (data: SignupRequest) => Promise<unknown>;
   nextStep: () => void;
 }
 
-export default function SignupPassword({ signupData, nextStep }: SignupPasswordProps) {
+export default function SignupPassword({ signup, nextStep }: SignupPasswordProps) {
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormFields>();
+  } = useFormContext<SignupFields>();
 
-  const { email, verificationCode } = signupData;
-
-  const onSubmit: SubmitHandler<FormFields> = async ({ password }) => {
-    postSignup({ email, password, verificationCode }).then(() => {
+  const onSubmit: SubmitHandler<SignupFields> = ({ email, password, verificationCode }) => {
+    signup({ email, password, verificationCode }).then(() => {
       nextStep();
     });
   };

--- a/src/auth/signup/components/SignupPassword.tsx
+++ b/src/auth/signup/components/SignupPassword.tsx
@@ -5,7 +5,7 @@ import Addition from '../../Addition';
 import InputField from '../../../shared/InputField';
 import { SubmitHandler, useFormContext } from 'react-hook-form';
 import { SignupRequest } from '../remotes/query';
-import { SignupFields } from '../../../pages/SignupPage';
+import { SignupStepFields } from '../../../pages/SignupPage';
 
 interface SignupPasswordProps {
   signup: (data: SignupRequest) => Promise<unknown>;
@@ -17,9 +17,13 @@ export default function SignupPassword({ signup, nextStep }: SignupPasswordProps
     register,
     handleSubmit,
     formState: { errors },
-  } = useFormContext<SignupFields>();
+  } = useFormContext<SignupStepFields>();
 
-  const onSubmit: SubmitHandler<SignupFields> = ({ email, password, verificationCode }) => {
+  const onSubmit: SubmitHandler<SignupStepFields> = ({
+    emailStep: { email },
+    passwordStep: { password },
+    verificationStep: { verificationCode },
+  }) => {
     signup({ email, password, verificationCode }).then(() => {
       nextStep();
     });
@@ -34,27 +38,27 @@ export default function SignupPassword({ signup, nextStep }: SignupPasswordProps
         <Spacing size={32} />
         <InputField type="password">
           <SignForm.Input
-            {...register('password', {
+            {...register('passwordStep.password', {
               required: true,
             })}
             placeholder="Password"
-            hasError={!!errors.password}
+            hasError={!!errors.passwordStep?.password}
           />
         </InputField>
         <Spacing size={16} />
 
-        <InputField type="password" bottomText={errors.confirmPassword?.message}>
+        <InputField type="password" bottomText={errors.passwordStep?.confirmPassword?.message}>
           <SignForm.Input
-            {...register('confirmPassword', {
+            {...register('passwordStep.confirmPassword', {
               validate: (confirmPassword, formValues) => {
-                if (confirmPassword !== formValues.password) {
+                if (confirmPassword !== formValues.passwordStep?.password) {
                   return 'The password does not match. Please check again.';
                 }
                 return true;
               },
             })}
             placeholder="Confirm password"
-            hasError={!!errors.confirmPassword}
+            hasError={!!errors.passwordStep?.confirmPassword}
           />
         </InputField>
 

--- a/src/auth/signup/components/SignupPassword.tsx
+++ b/src/auth/signup/components/SignupPassword.tsx
@@ -5,7 +5,7 @@ import Addition from '../../Addition';
 import InputField from '../../../shared/InputField';
 import { SubmitHandler, useFormContext } from 'react-hook-form';
 import { SignupRequest } from '../remotes/query';
-import { SignupStepFields } from '../../../pages/SignupPage';
+import { SignupFields } from '../../../pages/SignupPage';
 
 interface SignupPasswordProps {
   signup: (data: SignupRequest) => Promise<unknown>;
@@ -17,13 +17,9 @@ export default function SignupPassword({ signup, nextStep }: SignupPasswordProps
     register,
     handleSubmit,
     formState: { errors },
-  } = useFormContext<SignupStepFields>();
+  } = useFormContext<SignupFields>();
 
-  const onSubmit: SubmitHandler<SignupStepFields> = ({
-    emailStep: { email },
-    passwordStep: { password },
-    verificationStep: { verificationCode },
-  }) => {
+  const onSubmit: SubmitHandler<SignupFields> = ({ email, verificationCode, password: { password } }) => {
     signup({ email, password, verificationCode }).then(() => {
       nextStep();
     });
@@ -38,27 +34,27 @@ export default function SignupPassword({ signup, nextStep }: SignupPasswordProps
         <Spacing size={32} />
         <InputField type="password">
           <SignForm.Input
-            {...register('passwordStep.password', {
+            {...register('password.password', {
               required: true,
             })}
             placeholder="Password"
-            hasError={!!errors.passwordStep?.password}
+            hasError={!!errors.password?.password?.message}
           />
         </InputField>
         <Spacing size={16} />
 
-        <InputField type="password" bottomText={errors.passwordStep?.confirmPassword?.message}>
+        <InputField type="password" bottomText={errors.password?.confirmPassword?.message}>
           <SignForm.Input
-            {...register('passwordStep.confirmPassword', {
+            {...register('password.confirmPassword', {
               validate: (confirmPassword, formValues) => {
-                if (confirmPassword !== formValues.passwordStep?.password) {
+                if (confirmPassword !== formValues.password?.password) {
                   return 'The password does not match. Please check again.';
                 }
                 return true;
               },
             })}
             placeholder="Confirm password"
-            hasError={!!errors.passwordStep?.confirmPassword}
+            hasError={!!errors.password?.confirmPassword}
           />
         </InputField>
 

--- a/src/auth/signup/components/SignupVerification.tsx
+++ b/src/auth/signup/components/SignupVerification.tsx
@@ -7,10 +7,9 @@ import { Spacing } from '../../../shared/Spacing';
 import { postEmailVerification, postEmailVerificationCheck } from '../remotes/query';
 import envelopeBlackIcon from '../../../assets/icons/envelope-black.svg';
 import Addition from '../../Addition';
-import { useFormContext } from 'react-hook-form';
+import { SubmitHandler, useFormContext } from 'react-hook-form';
 import InputField from '../../../shared/InputField';
 import { SignupFields } from '../../../pages/SignupPage';
-import { FormEvent } from 'react';
 
 interface SignupVerificationProps {
   nextStep: () => void;
@@ -20,16 +19,13 @@ export default function SignupVerification({ nextStep }: SignupVerificationProps
   const {
     register,
     watch,
-    getValues,
+    handleSubmit,
     formState: { errors },
   } = useFormContext<SignupFields>();
 
   const email = watch('email');
 
-  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    const { email, verificationCode } = getValues();
-
+  const onSubmit: SubmitHandler<SignupFields> = ({ email, verificationCode }) => {
     postEmailVerificationCheck({ email, verificationCode }).then(() => {
       nextStep();
     });
@@ -37,7 +33,7 @@ export default function SignupVerification({ nextStep }: SignupVerificationProps
 
   return (
     <>
-      <SignForm onSubmit={onSubmit}>
+      <SignForm onSubmit={handleSubmit(onSubmit)}>
         <SignForm.Title name="Sign up" />
         <Spacing size={8} />
         <SignForm.Description content="Check your mailbox." />

--- a/src/auth/signup/components/SignupVerification.tsx
+++ b/src/auth/signup/components/SignupVerification.tsx
@@ -7,39 +7,37 @@ import { Spacing } from '../../../shared/Spacing';
 import { postEmailVerification, postEmailVerificationCheck } from '../remotes/query';
 import envelopeBlackIcon from '../../../assets/icons/envelope-black.svg';
 import Addition from '../../Addition';
-import { SubmitHandler, useForm } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 import InputField from '../../../shared/InputField';
-import { SignupData } from '../../../pages/SignupPage';
-
-interface FormFields {
-  verificationCode: string;
-}
+import { SignupFields } from '../../../pages/SignupPage';
+import { FormEvent } from 'react';
 
 interface SignupVerificationProps {
-  signupData: SignupData;
-  setSignupData: (key: keyof SignupData, value: SignupData[keyof SignupData]) => void;
   nextStep: () => void;
 }
 
-export default function SignupVerification({ signupData, setSignupData, nextStep }: SignupVerificationProps) {
+export default function SignupVerification({ nextStep }: SignupVerificationProps) {
   const {
     register,
-    handleSubmit,
+    watch,
+    getValues,
     formState: { errors },
-  } = useForm<FormFields>();
+  } = useFormContext<SignupFields>();
 
-  const { email } = signupData;
+  const email = watch('email');
 
-  const submitVerificationCode: SubmitHandler<FormFields> = ({ verificationCode }) => {
+  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const { email, verificationCode } = getValues();
+
     postEmailVerificationCheck({ email, verificationCode }).then(() => {
-      setSignupData('verificationCode', verificationCode);
       nextStep();
     });
   };
 
   return (
     <>
-      <SignForm onSubmit={handleSubmit(submitVerificationCode)}>
+      <SignForm onSubmit={onSubmit}>
         <SignForm.Title name="Sign up" />
         <Spacing size={8} />
         <SignForm.Description content="Check your mailbox." />

--- a/src/auth/signup/components/SignupVerification.tsx
+++ b/src/auth/signup/components/SignupVerification.tsx
@@ -9,7 +9,7 @@ import envelopeBlackIcon from '../../../assets/icons/envelope-black.svg';
 import Addition from '../../Addition';
 import { SubmitHandler, useFormContext } from 'react-hook-form';
 import InputField from '../../../shared/InputField';
-import { SignupFields } from '../../../pages/SignupPage';
+import { SignupStepFields } from '../../../pages/SignupPage';
 
 interface SignupVerificationProps {
   nextStep: () => void;
@@ -21,11 +21,14 @@ export default function SignupVerification({ nextStep }: SignupVerificationProps
     watch,
     handleSubmit,
     formState: { errors },
-  } = useFormContext<SignupFields>();
+  } = useFormContext<SignupStepFields>();
 
-  const email = watch('email');
+  const email = watch('emailStep.email');
 
-  const onSubmit: SubmitHandler<SignupFields> = ({ email, verificationCode }) => {
+  const onSubmit: SubmitHandler<SignupStepFields> = ({
+    emailStep: { email },
+    verificationStep: { verificationCode },
+  }) => {
     postEmailVerificationCheck({ email, verificationCode }).then(() => {
       nextStep();
     });
@@ -38,13 +41,13 @@ export default function SignupVerification({ nextStep }: SignupVerificationProps
         <Spacing size={8} />
         <SignForm.Description content="Check your mailbox." />
         <Spacing size={32} />
-        <InputField type="text" bottomText={errors.verificationCode?.message}>
+        <InputField type="text" bottomText={errors.verificationStep?.verificationCode?.message}>
           <SignForm.Input
-            {...register('verificationCode', {
+            {...register('verificationStep.verificationCode', {
               required: true,
             })}
             placeholder="Verification code"
-            hasError={!!errors.verificationCode}
+            hasError={!!errors.verificationStep?.verificationCode}
           />
         </InputField>
         <Spacing size={56} />

--- a/src/auth/signup/components/SignupVerification.tsx
+++ b/src/auth/signup/components/SignupVerification.tsx
@@ -9,7 +9,7 @@ import envelopeBlackIcon from '../../../assets/icons/envelope-black.svg';
 import Addition from '../../Addition';
 import { SubmitHandler, useFormContext } from 'react-hook-form';
 import InputField from '../../../shared/InputField';
-import { SignupStepFields } from '../../../pages/SignupPage';
+import { SignupFields } from '../../../pages/SignupPage';
 
 interface SignupVerificationProps {
   nextStep: () => void;
@@ -21,14 +21,11 @@ export default function SignupVerification({ nextStep }: SignupVerificationProps
     watch,
     handleSubmit,
     formState: { errors },
-  } = useFormContext<SignupStepFields>();
+  } = useFormContext<SignupFields>();
 
-  const email = watch('emailStep.email');
+  const email = watch('email');
 
-  const onSubmit: SubmitHandler<SignupStepFields> = ({
-    emailStep: { email },
-    verificationStep: { verificationCode },
-  }) => {
+  const onSubmit: SubmitHandler<SignupFields> = ({ email, verificationCode }) => {
     postEmailVerificationCheck({ email, verificationCode }).then(() => {
       nextStep();
     });
@@ -41,13 +38,13 @@ export default function SignupVerification({ nextStep }: SignupVerificationProps
         <Spacing size={8} />
         <SignForm.Description content="Check your mailbox." />
         <Spacing size={32} />
-        <InputField type="text" bottomText={errors.verificationStep?.verificationCode?.message}>
+        <InputField type="text" bottomText={errors.verificationCode?.message}>
           <SignForm.Input
-            {...register('verificationStep.verificationCode', {
+            {...register('verificationCode', {
               required: true,
             })}
             placeholder="Verification code"
-            hasError={!!errors.verificationStep?.verificationCode}
+            hasError={!!errors.verificationCode}
           />
         </InputField>
         <Spacing size={56} />

--- a/src/auth/signup/remotes/query.ts
+++ b/src/auth/signup/remotes/query.ts
@@ -1,13 +1,19 @@
 import { http } from '../../../utils/http';
 
-export const postEmailVerification = (requestBody: { email: string }) => {
+export interface SignupRequest {
+  email: string;
+  password: string;
+  verificationCode: string;
+}
+
+export const postEmailVerification = (requestBody: Pick<SignupRequest, 'email'>) => {
   return http.post('/auth/verification-code', requestBody);
 };
 
-export const postEmailVerificationCheck = (requestBody: { email: string; verificationCode: string }) => {
+export const postEmailVerificationCheck = (requestBody: Pick<SignupRequest, 'email' | 'verificationCode'>) => {
   return http.post('/auth/verification-code/check', requestBody);
 };
 
-export const postSignup = (requestBody: { email: string; password: string; verificationCode: string }) => {
+export const postSignup = (requestBody: SignupRequest) => {
   return http.post('/sign-up', requestBody);
 };

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,13 +1,16 @@
-import { useState } from 'react';
 import { useFunnel } from '../hooks/use-funnel/useFunnel';
 import SignupEmail from '../auth/signup/components/SignupEmail';
 import SignupVerification from '../auth/signup/components/SignupVerification';
 import SignupPassword from '../auth/signup/components/SignupPassword';
 import SignupComplete from '../auth/signup/components/SignupComplete';
+import { FormProvider, useForm } from 'react-hook-form';
+import { SignupRequest, postSignup } from '../auth/signup/remotes/query';
 
-export interface SignupData {
+export interface SignupFields {
   email: string;
   verificationCode: string;
+  password: string;
+  confirmPassword: string;
 }
 
 export default function SignupPage() {
@@ -16,36 +19,31 @@ export default function SignupPage() {
     stepQueryKey: 'step',
   });
 
-  const [signupData, _setSignupData] = useState<SignupData>({
-    email: '',
-    verificationCode: '',
-  });
+  const methods = useForm<SignupFields>();
 
-  const setSignupData = (key: keyof SignupData, value: SignupData[keyof SignupData]) => {
-    _setSignupData((prev) => ({ ...prev, [key]: value }));
+  const signup = (data: SignupRequest) => {
+    return postSignup(data);
   };
 
   return (
-    <Funnel>
-      <Funnel.Step name="email">
-        <SignupEmail setSignupData={setSignupData} nextStep={() => setStep('verification')} />
-      </Funnel.Step>
+    <FormProvider {...methods}>
+      <Funnel>
+        <Funnel.Step name="email">
+          <SignupEmail nextStep={() => setStep('verification')} />
+        </Funnel.Step>
 
-      <Funnel.Step name="verification">
-        <SignupVerification
-          signupData={signupData}
-          setSignupData={setSignupData}
-          nextStep={() => setStep('password')}
-        />
-      </Funnel.Step>
+        <Funnel.Step name="verification">
+          <SignupVerification nextStep={() => setStep('password')} />
+        </Funnel.Step>
 
-      <Funnel.Step name="password">
-        <SignupPassword signupData={signupData} nextStep={() => setStep('complete')} />
-      </Funnel.Step>
+        <Funnel.Step name="password">
+          <SignupPassword signup={signup} nextStep={() => setStep('complete')} />
+        </Funnel.Step>
 
-      <Funnel.Step name="complete">
-        <SignupComplete />
-      </Funnel.Step>
-    </Funnel>
+        <Funnel.Step name="complete">
+          <SignupComplete />
+        </Funnel.Step>
+      </Funnel>
+    </FormProvider>
   );
 }

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -6,14 +6,10 @@ import SignupComplete from '../auth/signup/components/SignupComplete';
 import { FormProvider, useForm } from 'react-hook-form';
 import { SignupRequest, postSignup } from '../auth/signup/remotes/query';
 
-export interface SignupStepFields {
-  emailStep: {
-    email: string;
-  };
-  verificationStep: {
-    verificationCode: string;
-  };
-  passwordStep: {
+export interface SignupFields {
+  email: string;
+  verificationCode: string;
+  password: {
     password: string;
     confirmPassword: string;
   };
@@ -25,7 +21,7 @@ export default function SignupPage() {
     stepQueryKey: 'step',
   });
 
-  const methods = useForm<SignupStepFields>();
+  const methods = useForm<SignupFields>();
 
   const signup = (data: SignupRequest) => {
     return postSignup(data);

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -6,11 +6,17 @@ import SignupComplete from '../auth/signup/components/SignupComplete';
 import { FormProvider, useForm } from 'react-hook-form';
 import { SignupRequest, postSignup } from '../auth/signup/remotes/query';
 
-export interface SignupFields {
-  email: string;
-  verificationCode: string;
-  password: string;
-  confirmPassword: string;
+export interface SignupStepFields {
+  emailStep: {
+    email: string;
+  };
+  verificationStep: {
+    verificationCode: string;
+  };
+  passwordStep: {
+    password: string;
+    confirmPassword: string;
+  };
 }
 
 export default function SignupPage() {
@@ -19,7 +25,7 @@ export default function SignupPage() {
     stepQueryKey: 'step',
   });
 
-  const methods = useForm<SignupFields>();
+  const methods = useForm<SignupStepFields>();
 
   const signup = (data: SignupRequest) => {
     return postSignup(data);


### PR DESCRIPTION
## 🔨 작업 내용

- [x] 회원가입 requestBody에 대한 타입 정의
- [x] FormProvider 적용

## 💬 리뷰 참고사항

회원가입 Page 컴포넌트에서 해당 페이지에서 할 것 signup 함수를 정의했습니다

Page 컴포넌트를 봤을 때, 어떤 역할을 하는 컴포넌트인지 인지시키고 싶었고, SignupPassword 컴포넌트에 prop로 signup을 넘겨주는 것으로 실제 회원가입 요청이 이루어지는 컴포넌트라는 것을 식별할 수 있도록 하고 싶었습니다

그 후, 각 컴포넌트는 회원가입 useForm 인스턴스를 공유하여 사용하도록 구현했습니다

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

close #24 
