### PR TITLE
API endpoint가 타입스크립트의 보호를 받도록 리펙토링한다, http 유틸 함수의 메서드에서 요청과 응답에 대한 제네릭 타입을 넘겨준다

### DIFF
--- a/src/auth/login/remotes/query.ts
+++ b/src/auth/login/remotes/query.ts
@@ -5,7 +5,9 @@ interface GetEmailVerifiedResponse {
 }
 
 export const getEmailVerified = ({ email }: { email: string }) => {
-  return http.get<GetEmailVerifiedResponse>(`/auth/email/registered?email=${email}`);
+  return http.get<GetEmailVerifiedResponse>('/auth/email/registered', {
+    params: { email },
+  });
 };
 
 export interface PostLoginRequest {
@@ -19,5 +21,5 @@ export interface PostLoginResponse {
 }
 
 export const postLogin = (requestBody: PostLoginRequest) => {
-  return http.post<PostLoginResponse, PostLoginRequest>('/login', requestBody);
+  return http.post<PostLoginRequest, PostLoginResponse>('/login', requestBody);
 };

--- a/src/auth/signup/remotes/query.ts
+++ b/src/auth/signup/remotes/query.ts
@@ -7,13 +7,13 @@ export interface SignupRequest {
 }
 
 export const postEmailVerification = (requestBody: Pick<SignupRequest, 'email'>) => {
-  return http.post('/auth/verification-code', requestBody);
+  return http.post<Pick<SignupRequest, 'email'>>('/auth/verification-code', requestBody);
 };
 
 export const postEmailVerificationCheck = (requestBody: Pick<SignupRequest, 'email' | 'verificationCode'>) => {
-  return http.post('/auth/verification-code/check', requestBody);
+  return http.post<Pick<SignupRequest, 'email' | 'verificationCode'>>('/auth/verification-code/check', requestBody);
 };
 
 export const postSignup = (requestBody: SignupRequest) => {
-  return http.post('/sign-up', requestBody);
+  return http.post<SignupRequest>('/sign-up', requestBody);
 };

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,14 +1,38 @@
-import Axios from 'axios';
+import Axios, { AxiosRequestConfig } from 'axios';
 
 const axios = Axios.create({
   baseURL: import.meta.env.VITE_API_URL_DEV,
 });
 
 export const http = {
-  get: function get<Response>(url: string) {
-    return axios.get<Response>(url).then((res) => res.data);
+  get: <Response = unknown>(url: GetApiPath, config?: AxiosRequestConfig) => {
+    return axios.get<Response>(url, config).then((res) => res.data);
   },
-  post: function post<Response, Request>(url: string, body?: Request) {
-    return axios.post<Response>(url, body).then((res) => res.data);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  post: <Request = any, Response = unknown>(url: PostApiPath, body?: Request, config?: AxiosRequestConfig) => {
+    return axios.post<Response>(url, body, config).then((res) => res.data);
+  },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  patch: <Request = any, Response = unknown>(url: PatchApiPath, body?: Request, config?: AxiosRequestConfig) => {
+    return axios.patch<Response>(url, body, config).then((res) => res.data);
+  },
+  delete: <Response = unknown>(url: DeleteApiPath, config?: AxiosRequestConfig) => {
+    return axios.delete<Response>(url, config).then((res) => res.data);
   },
 };
+
+type GetApiPath = '/health-check' | '/auth/email/registered' | '/categories' | '/categories/id-by-path';
+
+type PostApiPath =
+  | '/sign-up'
+  | '/login'
+  | '/auth/verification-code'
+  | '/auth/verification-code/check'
+  | '/auth/password-reset/verify-code'
+  | '/auth/password-reset/code'
+  | '/categories'
+  | '/categories/path';
+
+type PatchApiPath = '/auth/reset-password' | `/categories${number}` | `/categories/${number}/parent`;
+
+type DeleteApiPath = `/categories/${number}`;


### PR DESCRIPTION
## 🔨 작업 내용

- [x] API 요청시, request, response의 타입을 제공하도록 한다
- [x] ApiPath 유니온 타입을 정의한다

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

close #41 
