### PR TITLE
비밀번호 초기화 페이지에 리액트 쿼리 및 유효성 검사를 적용

### DIFF
--- a/src/auth/reset/components/ResetEmail.tsx
+++ b/src/auth/reset/components/ResetEmail.tsx
@@ -7,6 +7,7 @@ import InputField from '../../../shared/InputField';
 import { AxiosError } from 'axios';
 import { postResetVerification } from '../remotes/query';
 import { ResetFields } from '../../../pages/ResetPage';
+import { useEffect } from 'react';
 
 interface ResetEmailProps {
   nextStep: () => void;
@@ -16,6 +17,7 @@ export default function ResetEmail({ nextStep }: ResetEmailProps) {
   const {
     register,
     handleSubmit,
+    setFocus,
     formState: { errors },
   } = useFormContext<ResetFields>();
 
@@ -28,6 +30,10 @@ export default function ResetEmail({ nextStep }: ResetEmailProps) {
         alert(`${error}, ${error.response?.data.errorCode}`);
       });
   };
+
+  useEffect(() => {
+    setFocus('email');
+  }, [setFocus]);
 
   return (
     <SignForm onSubmit={handleSubmit(submitEmail)}>

--- a/src/auth/reset/components/ResetEmail.tsx
+++ b/src/auth/reset/components/ResetEmail.tsx
@@ -32,10 +32,13 @@ export default function ResetEmail({ nextStep }: ResetEmailProps) {
         onError: (error) => {
           if (isAxiosError(error)) {
             if (error.response?.data.errorCode === 'MEMBER_NOT_FOUND') {
-              setError('email', {
-                type: '400',
-                message: 'Member with the given email does not exist.',
-              });
+              setError(
+                'email',
+                {
+                  message: 'Member with the given email does not exist.',
+                },
+                { shouldFocus: true },
+              );
             }
           }
         },

--- a/src/auth/reset/components/ResetEmail.tsx
+++ b/src/auth/reset/components/ResetEmail.tsx
@@ -4,8 +4,7 @@ import { css } from '@emotion/react';
 import envelopeWhiteIcon from '../../../assets/icons/envelope-white.svg';
 import { SubmitHandler, useFormContext } from 'react-hook-form';
 import InputField from '../../../shared/InputField';
-import { AxiosError } from 'axios';
-import { postResetVerification } from '../remotes/query';
+import { usePostResetVerification } from '../remotes/query';
 import { ResetFields } from '../../../pages/ResetPage';
 import { useEffect } from 'react';
 
@@ -21,14 +20,16 @@ export default function ResetEmail({ nextStep }: ResetEmailProps) {
     formState: { errors },
   } = useFormContext<ResetFields>();
 
+  const { mutate: postResetVerification } = usePostResetVerification();
+
   const submitEmail: SubmitHandler<ResetFields> = ({ email }) => {
-    postResetVerification({ email })
-      .then(() => {
-        nextStep();
-      })
-      .catch((error: AxiosError<{ errorCode: string; detail: string }>) => {
-        alert(`${error}, ${error.response?.data.errorCode}`);
-      });
+    postResetVerification(
+      { email },
+      {
+        onSuccess: () => nextStep(),
+        onError: (error) => alert(error),
+      },
+    );
   };
 
   useEffect(() => {

--- a/src/auth/reset/components/ResetPassword.tsx
+++ b/src/auth/reset/components/ResetPassword.tsx
@@ -29,6 +29,7 @@ export default function ResetPassword({ resetPassword, nextStep }: ResetPassword
       { email, newPassword, verificationCode },
       {
         onSuccess: () => nextStep(),
+        onError: (error) => alert(error),
       },
     );
   };

--- a/src/auth/reset/components/ResetPassword.tsx
+++ b/src/auth/reset/components/ResetPassword.tsx
@@ -22,15 +22,15 @@ export default function ResetPassword({ resetPassword, nextStep }: ResetPassword
   const submitResetPassword: SubmitHandler<ResetFields> = async ({
     email,
     verificationCode,
-    password: { password },
+    password: { newPassword },
   }) => {
-    resetPassword({ email, password, verificationCode }).then(() => {
+    resetPassword({ email, newPassword, verificationCode }).then(() => {
       nextStep();
     });
   };
 
   useEffect(() => {
-    setFocus('password.password');
+    setFocus('password.newPassword');
   }, [setFocus]);
 
   return (
@@ -41,11 +41,11 @@ export default function ResetPassword({ resetPassword, nextStep }: ResetPassword
       <Spacing size={32} />
       <InputField type="password">
         <SignForm.Input
-          {...register('password.password', {
+          {...register('password.newPassword', {
             required: true,
           })}
           placeholder="Password"
-          hasError={!!errors.password?.password}
+          hasError={!!errors.password?.newPassword}
         />
       </InputField>
       <Spacing size={12} />
@@ -53,7 +53,7 @@ export default function ResetPassword({ resetPassword, nextStep }: ResetPassword
         <SignForm.Input
           {...register('password.confirmPassword', {
             validate: (confirmPassword, formValues) => {
-              if (confirmPassword !== formValues.password.password) {
+              if (confirmPassword !== formValues.password.newPassword) {
                 return 'The password does not match. Please check again.';
               }
               return true;

--- a/src/auth/reset/components/ResetPassword.tsx
+++ b/src/auth/reset/components/ResetPassword.tsx
@@ -5,9 +5,10 @@ import InputField from '../../../shared/InputField';
 import { ResetFields } from '../../../pages/ResetPage';
 import { ResetPasswordRequest } from '../remotes/query';
 import { useEffect } from 'react';
+import { UseMutateFunction } from '@tanstack/react-query';
 
 interface ResetPasswordProps {
-  resetPassword: (data: ResetPasswordRequest) => Promise<unknown>;
+  resetPassword: UseMutateFunction<unknown, Error, ResetPasswordRequest, unknown>;
   nextStep: () => void;
 }
 
@@ -24,9 +25,12 @@ export default function ResetPassword({ resetPassword, nextStep }: ResetPassword
     verificationCode,
     password: { newPassword },
   }) => {
-    resetPassword({ email, newPassword, verificationCode }).then(() => {
-      nextStep();
-    });
+    resetPassword(
+      { email, newPassword, verificationCode },
+      {
+        onSuccess: () => nextStep(),
+      },
+    );
   };
 
   useEffect(() => {

--- a/src/auth/reset/components/ResetPassword.tsx
+++ b/src/auth/reset/components/ResetPassword.tsx
@@ -42,30 +42,42 @@ export default function ResetPassword({ resetPassword, nextStep }: ResetPassword
     <SignForm onSubmit={handleSubmit(submitResetPassword)}>
       <SignForm.Title name="Reset password" />
       <Spacing size={8} />
-      <SignForm.Description content="Set your new password." />
+      <SignForm.Description content="The password must contain at least 7 characters including 1 upper case, 1 lower case, and 1 special character(@, #, $, %, *, !)." />
       <Spacing size={32} />
       <InputField type="password">
         <SignForm.Input
           {...register('password.newPassword', {
-            required: true,
+            required: 'The password must be at least 7 characters long.',
+            minLength: {
+              value: 7,
+              message: 'The password must be at least 7 characters long.',
+            },
+            pattern: {
+              value: /^(?=.*[A-Z])(?=.*[a-z])(?=.*[@#$%*!]).+$/,
+              message: 'The password must contain a mix of letters and at least one symbol.',
+            },
           })}
           placeholder="Password"
           hasError={!!errors.password?.newPassword}
         />
       </InputField>
       <Spacing size={12} />
-      <InputField type="password" bottomText={errors.password?.confirmPassword?.message}>
+      <InputField
+        type="password"
+        bottomText={errors.password?.newPassword?.message || errors.password?.confirmPassword?.message}
+      >
         <SignForm.Input
           {...register('password.confirmPassword', {
-            validate: (confirmPassword, formValues) => {
-              if (confirmPassword !== formValues.password.newPassword) {
-                return 'The password does not match. Please check again.';
-              }
-              return true;
+            validate: {
+              matchConfirmPassword: (confirmPassword, formValues) => {
+                if (confirmPassword !== formValues.password.newPassword) {
+                  return 'The password does not match. Please check again.';
+                }
+              },
             },
           })}
           placeholder="Confirm password"
-          hasError={!!errors.password?.confirmPassword}
+          hasError={!errors.password?.newPassword && !!errors.password?.confirmPassword}
         />
       </InputField>
       <Spacing size={56} />

--- a/src/auth/reset/components/ResetPassword.tsx
+++ b/src/auth/reset/components/ResetPassword.tsx
@@ -4,6 +4,7 @@ import { SubmitHandler, useFormContext } from 'react-hook-form';
 import InputField from '../../../shared/InputField';
 import { ResetFields } from '../../../pages/ResetPage';
 import { ResetPasswordRequest } from '../remotes/query';
+import { useEffect } from 'react';
 
 interface ResetPasswordProps {
   resetPassword: (data: ResetPasswordRequest) => Promise<unknown>;
@@ -14,6 +15,7 @@ export default function ResetPassword({ resetPassword, nextStep }: ResetPassword
   const {
     register,
     handleSubmit,
+    setFocus,
     formState: { errors },
   } = useFormContext<ResetFields>();
 
@@ -26,6 +28,10 @@ export default function ResetPassword({ resetPassword, nextStep }: ResetPassword
       nextStep();
     });
   };
+
+  useEffect(() => {
+    setFocus('password.password');
+  }, [setFocus]);
 
   return (
     <SignForm onSubmit={handleSubmit(submitResetPassword)}>

--- a/src/auth/reset/components/ResetPassword.tsx
+++ b/src/auth/reset/components/ResetPassword.tsx
@@ -29,7 +29,6 @@ export default function ResetPassword({ resetPassword, nextStep }: ResetPassword
       { email, newPassword, verificationCode },
       {
         onSuccess: () => nextStep(),
-        onError: (error) => alert(error),
       },
     );
   };

--- a/src/auth/reset/components/ResetVerification.tsx
+++ b/src/auth/reset/components/ResetVerification.tsx
@@ -9,6 +9,7 @@ import InputField from '../../../shared/InputField';
 import { usePostResetVerification, usePostResetVerificationCheck } from '../remotes/query';
 import { ResetFields } from '../../../pages/ResetPage';
 import { useEffect } from 'react';
+import { isAxiosError } from 'axios';
 
 interface ResetVerificationProps {
   nextStep: () => void;
@@ -20,6 +21,7 @@ export default function ResetVerification({ nextStep }: ResetVerificationProps) 
     watch,
     handleSubmit,
     setFocus,
+    setError,
     formState: { errors },
   } = useFormContext<ResetFields>();
 
@@ -33,7 +35,16 @@ export default function ResetVerification({ nextStep }: ResetVerificationProps) 
       { email, verificationCode },
       {
         onSuccess: () => nextStep(),
-        onError: (error) => alert(error),
+        onError: (error) => {
+          if (isAxiosError(error)) {
+            if (error.response?.data.errorCode === 'INVALID_VERIFICATION_CODE') {
+              setError('verificationCode', {
+                type: '400',
+                message: 'Verification code does not match. Please check again.',
+              });
+            }
+          }
+        },
       },
     );
   };
@@ -51,7 +62,7 @@ export default function ResetVerification({ nextStep }: ResetVerificationProps) 
       <InputField type="text" bottomText={errors.verificationCode?.message}>
         <SignForm.Input
           {...register('verificationCode', {
-            required: true,
+            required: 'Enter certification code.',
           })}
           placeholder="Verification code"
           hasError={!!errors.verificationCode}

--- a/src/auth/reset/components/ResetVerification.tsx
+++ b/src/auth/reset/components/ResetVerification.tsx
@@ -8,6 +8,7 @@ import { SubmitHandler, useFormContext } from 'react-hook-form';
 import InputField from '../../../shared/InputField';
 import { postResetVerification, postResetVerificationCheck } from '../remotes/query';
 import { ResetFields } from '../../../pages/ResetPage';
+import { useEffect } from 'react';
 
 interface ResetVerificationProps {
   nextStep: () => void;
@@ -16,8 +17,9 @@ interface ResetVerificationProps {
 export default function ResetVerification({ nextStep }: ResetVerificationProps) {
   const {
     register,
-    handleSubmit,
     watch,
+    handleSubmit,
+    setFocus,
     formState: { errors },
   } = useFormContext<ResetFields>();
 
@@ -28,6 +30,10 @@ export default function ResetVerification({ nextStep }: ResetVerificationProps) 
       nextStep();
     });
   };
+
+  useEffect(() => {
+    setFocus('verificationCode');
+  }, [setFocus]);
 
   return (
     <SignForm onSubmit={handleSubmit(submitVerificationCode)}>

--- a/src/auth/reset/components/ResetVerification.tsx
+++ b/src/auth/reset/components/ResetVerification.tsx
@@ -6,7 +6,7 @@ import { Spacing } from '../../../shared/Spacing';
 import envelopeBlackIcon from '../../../assets/icons/envelope-black.svg';
 import { SubmitHandler, useFormContext } from 'react-hook-form';
 import InputField from '../../../shared/InputField';
-import { postResetVerification, postResetVerificationCheck } from '../remotes/query';
+import { usePostResetVerification, usePostResetVerificationCheck } from '../remotes/query';
 import { ResetFields } from '../../../pages/ResetPage';
 import { useEffect } from 'react';
 
@@ -25,10 +25,17 @@ export default function ResetVerification({ nextStep }: ResetVerificationProps) 
 
   const email = watch('email');
 
+  const { mutate: postResetVerification } = usePostResetVerification();
+  const { mutate: postResetVerificationCheck } = usePostResetVerificationCheck();
+
   const submitVerificationCode: SubmitHandler<ResetFields> = ({ email, verificationCode }) => {
-    postResetVerificationCheck({ email, verificationCode }).then(() => {
-      nextStep();
-    });
+    postResetVerificationCheck(
+      { email, verificationCode },
+      {
+        onSuccess: () => nextStep(),
+        onError: (error) => alert(error),
+      },
+    );
   };
 
   useEffect(() => {

--- a/src/auth/reset/remotes/query.ts
+++ b/src/auth/reset/remotes/query.ts
@@ -7,7 +7,7 @@ export interface ResetPasswordRequest {
   verificationCode: string;
 }
 
-export const postResetVerification = ({ email }: Pick<ResetPasswordRequest, 'email'>) => {
+const postResetVerification = ({ email }: Pick<ResetPasswordRequest, 'email'>) => {
   return http.post('/auth/password-reset/code', { email });
 };
 
@@ -18,7 +18,7 @@ export const usePostResetVerification = () => {
   });
 };
 
-export const postResetVerificationCheck = ({
+const postResetVerificationCheck = ({
   email,
   verificationCode,
 }: Pick<ResetPasswordRequest, 'email' | 'verificationCode'>) => {
@@ -32,7 +32,7 @@ export const usePostResetVerificationCheck = () => {
   });
 };
 
-export const patchResetPassword = ({ email, newPassword, verificationCode }: ResetPasswordRequest) => {
+const patchResetPassword = ({ email, newPassword, verificationCode }: ResetPasswordRequest) => {
   return http.patch('/auth/reset-password', { email, newPassword, verificationCode });
 };
 

--- a/src/auth/reset/remotes/query.ts
+++ b/src/auth/reset/remotes/query.ts
@@ -2,7 +2,7 @@ import { http } from '../../../utils/http';
 
 export interface ResetPasswordRequest {
   email: string;
-  password: string;
+  newPassword: string;
   verificationCode: string;
 }
 
@@ -17,6 +17,6 @@ export const postResetVerificationCheck = ({
   return http.post('/auth/password-reset/verify-code', { email, verificationCode });
 };
 
-export const postResetPassword = ({ email, password, verificationCode }: ResetPasswordRequest) => {
-  return http.post('/auth/reset-password', { email, password, verificationCode });
+export const patchResetPassword = ({ email, newPassword, verificationCode }: ResetPasswordRequest) => {
+  return http.patch('/auth/reset-password', { email, newPassword, verificationCode });
 };

--- a/src/auth/reset/remotes/query.ts
+++ b/src/auth/reset/remotes/query.ts
@@ -11,11 +11,25 @@ export const postResetVerification = ({ email }: Pick<ResetPasswordRequest, 'ema
   return http.post('/auth/password-reset/code', { email });
 };
 
+export const usePostResetVerification = () => {
+  return useMutation({
+    mutationKey: ['postResetVerification'],
+    mutationFn: (data: Pick<ResetPasswordRequest, 'email'>) => postResetVerification(data),
+  });
+};
+
 export const postResetVerificationCheck = ({
   email,
   verificationCode,
 }: Pick<ResetPasswordRequest, 'email' | 'verificationCode'>) => {
   return http.post('/auth/password-reset/verify-code', { email, verificationCode });
+};
+
+export const usePostResetVerificationCheck = () => {
+  return useMutation({
+    mutationKey: ['postResetVerificationCheck'],
+    mutationFn: (data: Pick<ResetPasswordRequest, 'email' | 'verificationCode'>) => postResetVerificationCheck(data),
+  });
 };
 
 export const patchResetPassword = ({ email, newPassword, verificationCode }: ResetPasswordRequest) => {

--- a/src/auth/reset/remotes/query.ts
+++ b/src/auth/reset/remotes/query.ts
@@ -1,3 +1,4 @@
+import { useMutation } from '@tanstack/react-query';
 import { http } from '../../../utils/http';
 
 export interface ResetPasswordRequest {
@@ -19,4 +20,11 @@ export const postResetVerificationCheck = ({
 
 export const patchResetPassword = ({ email, newPassword, verificationCode }: ResetPasswordRequest) => {
   return http.patch('/auth/reset-password', { email, newPassword, verificationCode });
+};
+
+export const usePatchResetPassword = () => {
+  return useMutation({
+    mutationKey: ['patchResetPassword'],
+    mutationFn: (data: ResetPasswordRequest) => patchResetPassword(data),
+  });
 };

--- a/src/pages/ResetPage.tsx
+++ b/src/pages/ResetPage.tsx
@@ -4,13 +4,13 @@ import ResetVerification from '../auth/reset/components/ResetVerification';
 import ResetPassword from '../auth/reset/components/ResetPassword';
 import ResetComplete from '../auth/reset/components/ResetComplete';
 import { FormProvider, useForm } from 'react-hook-form';
-import { ResetPasswordRequest, postResetPassword } from '../auth/reset/remotes/query';
+import { ResetPasswordRequest, patchResetPassword } from '../auth/reset/remotes/query';
 
 export interface ResetFields {
   email: string;
   verificationCode: string;
   password: {
-    password: string;
+    newPassword: string;
     confirmPassword: string;
   };
 }
@@ -24,7 +24,7 @@ export default function ResetPage() {
   const methods = useForm<ResetFields>();
 
   const resetPassword = (data: ResetPasswordRequest) => {
-    return postResetPassword(data);
+    return patchResetPassword(data);
   };
 
   return (

--- a/src/pages/ResetPage.tsx
+++ b/src/pages/ResetPage.tsx
@@ -21,7 +21,9 @@ export default function ResetPage() {
     stepQueryKey: 'step',
   });
 
-  const methods = useForm<ResetFields>();
+  const methods = useForm<ResetFields>({
+    reValidateMode: 'onSubmit',
+  });
 
   const { mutate: resetPassword } = usePatchResetPassword();
 

--- a/src/pages/ResetPage.tsx
+++ b/src/pages/ResetPage.tsx
@@ -4,7 +4,7 @@ import ResetVerification from '../auth/reset/components/ResetVerification';
 import ResetPassword from '../auth/reset/components/ResetPassword';
 import ResetComplete from '../auth/reset/components/ResetComplete';
 import { FormProvider, useForm } from 'react-hook-form';
-import { ResetPasswordRequest, patchResetPassword } from '../auth/reset/remotes/query';
+import { usePatchResetPassword } from '../auth/reset/remotes/query';
 
 export interface ResetFields {
   email: string;
@@ -23,9 +23,7 @@ export default function ResetPage() {
 
   const methods = useForm<ResetFields>();
 
-  const resetPassword = (data: ResetPasswordRequest) => {
-    return patchResetPassword(data);
-  };
+  const { mutate: resetPassword } = usePatchResetPassword();
 
   return (
     <FormProvider {...methods}>


### PR DESCRIPTION
## 🔨 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

<!-- 작업 내용 -->

- 퍼널 스텝에 진입시 첫 인풋에 포커스
- api 메서드 및 리퀘스트 수정
- useMutation 적용
- 유효성 검사가 onSubmit에 동작하도록 reValidateMode 설정
- 유효성 검사 및 api 에러 메세지 추가

## 💬 리뷰 참고사항

> 원활한 리뷰를 위해 전달하고 싶은 맥락(특정 파일, 디렉터리 등등)  
> 리뷰어가 특별히 봐주었으면 하는 부분

<!-- 참고 사항 -->

BottomText가 가지고 있는 문제점이 많은데, 현재 PR에서는 BottomText를 그대로 쓰는 방향으로 진행했습니다. (아래 이미지 참고)
디자인을 참고하여 다시 확인해 본 결과 캘린더 쪽에서는 BottomText가 InputField에 포함될 필요가 없어 보이며,
회원가입에서도 합쳐져있는 것이 에러메세지 관리 측면과 스타일 관리(여백)에 있어 불리한 면이 있어, InputField에서 분리하여 관리하는 것이 더 좋아보입니다.

<img width="478" alt="image" src="https://github.com/girok-web/girok-web/assets/87710730/cb87a6d6-be9e-4579-8c83-eb4ed026a022">


## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

close #33 
