### PR TITLE
이벤트 폼의 토글칩 구현

### DIFF
--- a/src/components/Icon/SvgComponents.tsx
+++ b/src/components/Icon/SvgComponents.tsx
@@ -96,3 +96,20 @@ export function EyeOff({ ...props }) {
     </svg>
   );
 }
+
+export function ChipPlus({ ...props }) {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M2 5.89941L10 5.89941" stroke="currentColor" stroke-linecap="round" />
+      <path d="M6 10L6 2" stroke="currentColor" stroke-linecap="round" />
+    </svg>
+  );
+}
+
+export function ChipMinus({ ...props }) {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M2 6H10" stroke="currentColor" stroke-linecap="round" />
+    </svg>
+  );
+}

--- a/src/features/event-form/components/ToggleChip.tsx
+++ b/src/features/event-form/components/ToggleChip.tsx
@@ -2,15 +2,25 @@ import { css } from '@emotion/react';
 import { colorPalette } from '../../../styles/colorPalette';
 import { ChipMinus, ChipPlus } from '../../../components/Icon/SvgComponents';
 
-interface ToggleChip {
-  disabled?: boolean;
-  type: 'time' | 'field';
+interface BaseProps {
   label: string;
   selected: boolean;
   onClick: () => void;
 }
 
-function ToggleChip({ disabled = false, type, label, selected, onClick }: ToggleChip) {
+type TimeChipProps = BaseProps & {
+  type: 'time';
+  disabled?: boolean;
+};
+
+type FieldChipProps = BaseProps & {
+  type: 'field';
+  disabled?: never;
+};
+
+type ToggleChipProps = TimeChipProps | FieldChipProps;
+
+function ToggleChip({ disabled = false, type, label, selected, onClick }: ToggleChipProps) {
   return (
     <button
       css={css([
@@ -37,7 +47,7 @@ const base = css`
   border-radius: 16px;
 `;
 
-const timeStyle = ({ selected, disabled }: Pick<ToggleChip, 'selected' | 'disabled'>) => css`
+const timeStyle = ({ selected, disabled }: Pick<ToggleChipProps, 'selected' | 'disabled'>) => css`
   ${defaultTimeStyle};
   ${selected ? selectedTimeStyle : undefined};
   ${disabled ? disabledTimeStyle : undefined};
@@ -60,7 +70,7 @@ const disabledTimeStyle = css`
   color: ${colorPalette.gray2};
 `;
 
-const fieldStyle = ({ selected }: Pick<ToggleChip, 'selected'>) => css`
+const fieldStyle = ({ selected }: Pick<ToggleChipProps, 'selected'>) => css`
   ${defaultFieldStyle};
   ${selected ? selectedFieldStyle : undefined}
 `;

--- a/src/features/event-form/components/ToggleChip.tsx
+++ b/src/features/event-form/components/ToggleChip.tsx
@@ -56,9 +56,8 @@ const selectedTimeStyle = css`
 `;
 
 const disabledTimeStyle = css`
-  border: 1px solid ${colorPalette.gray0};
+  border: 1px solid ${colorPalette.gray2};
   color: ${colorPalette.gray2};
-  background-color: ${colorPalette.gray1};
 `;
 
 const fieldStyle = ({ selected }: Pick<ToggleChip, 'selected'>) => css`

--- a/src/features/event-form/components/ToggleChip.tsx
+++ b/src/features/event-form/components/ToggleChip.tsx
@@ -1,0 +1,79 @@
+import { css } from '@emotion/react';
+import { colorPalette } from '../../../styles/colorPalette';
+import { ChipMinus, ChipPlus } from '../../../components/Icon/SvgComponents';
+
+interface ToggleChip {
+  disabled?: boolean;
+  type: 'time' | 'field';
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}
+
+function ToggleChip({ disabled = false, type, label, selected, onClick }: ToggleChip) {
+  return (
+    <button
+      css={css([
+        base,
+        type === 'time' ? timeStyle({ selected, disabled }) : undefined,
+        type === 'field' ? fieldStyle({ selected }) : undefined,
+      ])}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {selected ? <ChipMinus /> : <ChipPlus />}
+      {label}
+    </button>
+  );
+}
+
+export default ToggleChip;
+
+const base = css`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 12px 8px 10px;
+  border-radius: 16px;
+`;
+
+const timeStyle = ({ selected, disabled }: Pick<ToggleChip, 'selected' | 'disabled'>) => css`
+  ${defaultTimeStyle};
+  ${selected ? selectedTimeStyle : undefined};
+  ${disabled ? disabledTimeStyle : undefined};
+`;
+
+const defaultTimeStyle = css`
+  height: 28px;
+  border: 1px solid ${colorPalette.gray2};
+  color: ${colorPalette.gray4};
+`;
+
+const selectedTimeStyle = css`
+  border: 1px solid ${colorPalette.gray3};
+  color: ${colorPalette.gray5};
+  background-color: ${colorPalette.gray1};
+`;
+
+const disabledTimeStyle = css`
+  border: 1px solid ${colorPalette.gray0};
+  color: ${colorPalette.gray2};
+  background-color: ${colorPalette.gray1};
+`;
+
+const fieldStyle = ({ selected }: Pick<ToggleChip, 'selected'>) => css`
+  ${defaultFieldStyle};
+  ${selected ? selectedFieldStyle : undefined}
+`;
+
+const defaultFieldStyle = css`
+  height: 32px;
+  border: 1px solid ${colorPalette.gray3};
+  color: ${colorPalette.gray5};
+`;
+
+const selectedFieldStyle = css`
+  border: 1px solid ${colorPalette.gray5};
+  color: ${colorPalette.white};
+  background-color: ${colorPalette.gray5};
+`;

--- a/src/features/event-form/components/ToggleChip.tsx
+++ b/src/features/event-form/components/ToggleChip.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { colorPalette } from '../../../styles/colorPalette';
-import { ChipMinus, ChipPlus } from '../../../components/Icon/SvgComponents';
+import Icon from '../../../components/Icon';
 
 interface BaseProps {
   label: string;
@@ -31,7 +31,7 @@ function ToggleChip({ disabled = false, type, label, selected, onClick }: Toggle
       onClick={onClick}
       disabled={disabled}
     >
-      {selected ? <ChipMinus /> : <ChipPlus />}
+      {selected ? <Icon name="chip-minus" /> : <Icon name="chip-plus" />}
       {label}
     </button>
   );


### PR DESCRIPTION
## 🔨 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명(이미지 첨부 가능)

<!-- 작업 내용 -->

이벤트 폼에서 사용되는 토글칩 두가지를 구현하였습니다.
두가지가 스타일을 공유하는 부분이 많고, 디자인에서도 같은 컴포넌트로 분류하였기에 하나의 컴포넌트로 구현하였습니다.

다만, `type=time`의 토글칩 같은 경우 `disabled`가 있는 반면,
`type=field`의 토글칩 같은 경우 `disabled`를 사용하지 않습니다.

`disabled`가 옵셔널이고 한 컴포넌트로 구현했기 때문에 `type=field`이면서 `disabled`인 상황이 생길수도 있지만,
`type=field`인 토글칩에서 `disabled`를 사용할 상황이 없기 때문에 헷갈리지 않을 것이라고 판단하고 그대로 묶어서 구현하였습니다.

### 사용법

#### 상태

```jsx
const [hasTime, setHasTime] = useState(false);
const [hasCategory, setHasCategory] = useState(false);
```

#### time

```jsx
<ToggleChip
  type="time"
  label="time"
  selected={hasTime}
  onClick={() => setHasTime((prev) => !prev)}
  disabled={멀티이벤트인경우}
/>
```

#### field

```jsx
<ToggleChip
  type="field"
  label="Category"
  selected={hasCategory}
  onClick={() => setHasCategory((prev) => !prev)}
/>
```

## 💬 리뷰 참고사항

> 원활한 리뷰를 위해 전달하고 싶은 맥락(특정 파일, 디렉터리 등등)  
> 리뷰어가 특별히 봐주었으면 하는 부분

<!-- 참고 사항 -->

### 구현한 토글칩 2가지

<img width="323" alt="image" src="https://github.com/girok-web/girok-web/assets/87710730/cc3b77d2-1bcf-4bea-be75-0cb3695110af">

### time

`default - selected - disabled`

<img width="168" alt="image" src="https://github.com/girok-web/girok-web/assets/87710730/cdf339d4-d781-4698-b16a-95769237e2b4">

`disabled`가 필요한 경우

<img width="296" alt="image" src="https://github.com/girok-web/girok-web/assets/87710730/3fa0f8dc-8927-4d74-b815-268626701108">

### field

`default - selected`

<img width="234" alt="image" src="https://github.com/girok-web/girok-web/assets/87710730/40ada1e1-e2e6-4f2c-be16-10ec4456d753">

## #️⃣ 연관된 이슈

> 연관된 이슈 번호를 모두 작성

close #54 
